### PR TITLE
Add cache debug info to development tools sheet

### DIFF
--- a/HealthTrends/Views/App/CacheDebugView.swift
+++ b/HealthTrends/Views/App/CacheDebugView.swift
@@ -1,0 +1,155 @@
+import HealthTrendsShared
+import SwiftUI
+
+/// Toggleable timestamp display that shows relative time by default and absolute time on tap
+struct ToggleableTimestamp: View {
+	let date: Date
+	@State private var showAbsolute = false
+
+	var body: some View {
+		Button(action: {
+			showAbsolute.toggle()
+		}) {
+			Text(showAbsolute ? formatAbsolute(date) : formatRelative(date))
+				.font(.caption)
+				.foregroundStyle(.primary)
+		}
+		.buttonStyle(.plain)
+	}
+
+	private func formatRelative(_ date: Date) -> String {
+		let formatter = RelativeDateTimeFormatter()
+		formatter.unitsStyle = .abbreviated
+		return formatter.localizedString(for: date, relativeTo: Date())
+	}
+
+	private func formatAbsolute(_ date: Date) -> String {
+		let formatter = DateFormatter()
+		formatter.dateStyle = .short
+		formatter.timeStyle = .medium
+		return formatter.string(from: date)
+	}
+}
+
+/// Displays cache state for debugging
+struct CacheDebugView: View {
+	@State private var todayCache: SharedEnergyData?
+	@State private var weekdayCache: WeekdayAverageCache?
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 16) {
+			// Today Data Cache Section
+			VStack(alignment: .leading, spacing: 8) {
+				Text("Today Data Cache")
+					.font(.headline)
+
+				if let cache = todayCache {
+					Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 4) {
+						GridRow {
+							Text("Last Cache Update:")
+								.foregroundStyle(.secondary)
+								.font(.caption)
+							ToggleableTimestamp(date: cache.lastUpdated)
+						}
+						GridRow {
+							Text("Last Sample Received:")
+								.foregroundStyle(.secondary)
+								.font(.caption)
+							if let timestamp = cache.latestSampleTimestamp {
+								ToggleableTimestamp(date: timestamp)
+							} else {
+								Text("N/A")
+									.foregroundStyle(.tertiary)
+									.font(.caption)
+							}
+						}
+					}
+				} else {
+					Text("No cache found")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+			}
+
+			Divider()
+
+			// Average Data Cache Section
+			VStack(alignment: .leading, spacing: 8) {
+				Text("Average Data Cache")
+					.font(.headline)
+
+				if let cache = weekdayCache {
+					Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 4) {
+						GridRow {
+							Text("Weekday")
+								.font(.caption)
+								.foregroundStyle(.secondary)
+							Text("Last Update")
+								.font(.caption)
+								.foregroundStyle(.secondary)
+							Text("Projected Total")
+								.font(.caption)
+								.foregroundStyle(.secondary)
+						}
+
+						ForEach(Weekday.allCases, id: \.rawValue) { weekday in
+							if let weekdayData = cache.cache(for: weekday) {
+								GridRow {
+									Text(weekdayName(for: weekday))
+										.font(.caption)
+									ToggleableTimestamp(date: weekdayData.cachedAt)
+									Text(formatCalories(weekdayData.projectedTotal))
+										.font(.caption)
+								}
+							} else {
+								GridRow {
+									Text(weekdayName(for: weekday))
+										.font(.caption)
+										.foregroundStyle(.secondary)
+									Text("—")
+										.font(.caption)
+										.foregroundStyle(.tertiary)
+									Text("—")
+										.font(.caption)
+										.foregroundStyle(.tertiary)
+								}
+							}
+						}
+					}
+				} else {
+					Text("No cache found")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+			}
+		}
+		.onAppear {
+			loadCacheData()
+		}
+	}
+
+	private func loadCacheData() {
+		// Load today's data cache
+		todayCache = try? SharedEnergyDataManager.shared.readEnergyData()
+
+		// Load weekday average cache
+		let cacheManager = AverageDataCacheManager()
+		weekdayCache = cacheManager.loadContainer()
+	}
+
+	private func formatCalories(_ calories: Double) -> String {
+		String(format: "%.0f kcal", calories)
+	}
+
+	private func weekdayName(for weekday: Weekday) -> String {
+		switch weekday {
+		case .sunday: return "Sun"
+		case .monday: return "Mon"
+		case .tuesday: return "Tue"
+		case .wednesday: return "Wed"
+		case .thursday: return "Thu"
+		case .friday: return "Fri"
+		case .saturday: return "Sat"
+		}
+	}
+}

--- a/HealthTrendsShared/Sources/HealthTrendsShared/AverageDataCache.swift
+++ b/HealthTrendsShared/Sources/HealthTrendsShared/AverageDataCache.swift
@@ -249,7 +249,7 @@ public final class AverageDataCacheManager: Sendable {
 	// MARK: - Private Helpers
 
 	/// Load the entire weekday cache container from disk
-	private func loadContainer() -> WeekdayAverageCache? {
+	public func loadContainer() -> WeekdayAverageCache? {
 		guard let fileURL = fileURL,
 			FileManager.default.fileExists(atPath: fileURL.path)
 		else {


### PR DESCRIPTION
## Summary
Added comprehensive cache debugging UI to the Development Tools sheet to help diagnose caching issues.

## Changes
- **New CacheDebugView component**: Displays today's data cache and weekday average caches
  - Shows last cache update times for today's data
  - Shows latest HealthKit sample timestamp
  - Displays all 7 weekday average caches with last update times and projected totals
- **Toggleable timestamps**: Tap to switch between relative ("5 min ago") and absolute format
- **New debug buttons**:
  - "Fetch health data" - triggers HealthKit queries (same as widget)
  - "Rebuild average data cache" - repopulates all weekday caches
- **Dev tools UX**: Sheet now expandable to full screen with .large detent
- **API change**: Made `AverageDataCacheManager.loadContainer()` public for debug access

## Test plan
- [x] Build succeeds
- [x] Open dev tools sheet and verify cache info displays
- [x] Tap timestamps to toggle formats
- [x] Test "Fetch health data" button updates cache timestamps
- [x] Test "Rebuild average data cache" button repopulates all weekdays
- [x] Verify sheet expands to full screen when swiped up

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)